### PR TITLE
Fix linear retraining workflow

### DIFF
--- a/.github/workflows/retrain-linear.yml
+++ b/.github/workflows/retrain-linear.yml
@@ -26,11 +26,8 @@ jobs:
           if [ -f requirements.txt ]; then
             pip install -r requirements.txt
           else
-            pip install google-auth gspread pandas numpy scikit-learn
+            pip install pandas numpy yfinance tensorflow-cpu scikit-learn joblib gspread google-auth google-auth-oauthlib
           fi
-          run: |
-            python -m pip install --upgrade pip
-            pip install pandas numpy yfinance tensorflow scikit-learn joblib gspread google-auth-oauthlib
 
       - name: Create service account JSON file
         env:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 streamlit==1.36.0
 pandas==2.2.2
 numpy==1.26.4
-scikit-learn==1.7.1
+scikit-learn==1.4.2
 plotly==5.22.0
 requests==2.32.3
 yfinance==0.2.44

--- a/train.py
+++ b/train.py
@@ -10,6 +10,7 @@ import joblib
 import gspread
 import argparse # New import for command-line arguments
 from sklearn.preprocessing import MinMaxScaler
+from sklearn.linear_model import LinearRegression
 
 # --- Constants ---
 WINDOW = 60
@@ -93,12 +94,15 @@ def build_model(n_features, window=WINDOW, n_out=len(HORIZONS)):
 
 def main():
     # 1. Set up argument parser to read arguments from the YAML file
-    parser = argparse.ArgumentParser(description="Train a CNN-LSTM model on stock data from Google Sheets.")
+    parser = argparse.ArgumentParser(description="Train stock prediction models on data from Google Sheets.")
+    parser.add_argument("--model", choices=["cnn-lstm", "linear"], default="cnn-lstm", help="Model type to train.")
     parser.add_argument("--sheet-id", required=True, help="ID of the Google Sheet containing stock symbols.")
     parser.add_argument("--worksheet", required=True, help="Name of the worksheet with the symbol list.")
     parser.add_argument("--symbol-column", default="Ticker", help="Name of the column containing the stock symbols.")
     args = parser.parse_args()
-    print(f"Received arguments: sheet-id='{args.sheet_id}', worksheet='{args.worksheet}', symbol-column='{args.symbol_column}'")
+    print(
+        f"Received arguments: model='{args.model}', sheet-id='{args.sheet_id}', worksheet='{args.worksheet}', symbol-column='{args.symbol_column}'"
+    )
 
     # 2. Authenticate with Google Sheets and fetch symbols
     # gspread automatically uses the GOOGLE_APPLICATION_CREDENTIALS env variable set in the workflow
@@ -126,13 +130,28 @@ def main():
     # 3. Run the ML pipeline using the fetched symbols
     raw = get_history(symbols, years=5)
     feat = make_features(raw)
+
+    if args.model == "linear":
+        df = feat.dropna(subset=["ma10", "ma50"])
+        if df.empty:
+            print("Error: Not enough data to train linear model.")
+            return
+        X = df[["ma10", "ma50"]].values
+        y = df["close"].values
+        model = LinearRegression()
+        model.fit(X, y)
+        os.makedirs("models", exist_ok=True)
+        joblib.dump(model, "models/linear_model.pkl")
+        print("✅ Successfully saved models/linear_model.pkl")
+        return
+
     X, y, scaler, feats = windowize(feat)
-    
+
     print(f"Created training dataset with shape X: {X.shape}, y: {y.shape}")
-    
+
     model = build_model(n_features=X.shape[-1])
     model.fit(X, y, epochs=8, batch_size=256, validation_split=0.1, verbose=2)
-    
+
     # 4. Save the trained model and scaler
     os.makedirs("models", exist_ok=True)
     model.save("models/cnn_lstm_ALL.keras")


### PR DESCRIPTION
## Summary
- correct scikit-learn dependency version
- clean retrain-linear workflow setup
- add linear model training option to train.py

## Testing
- `/usr/bin/python3 train.py --help` *(failed: No module named 'numpy')*
- `/usr/bin/python3 -m pytest` *(failed: No module named pytest)*


------
https://chatgpt.com/codex/tasks/task_e_68b8867ebb8c8324b190ed0b149826af